### PR TITLE
chore: add pre-commit hooks for linting and secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4  # Use the latest version
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.2  # Use the latest version
+    hooks:
+      - id: gitleaks 


### PR DESCRIPTION
Add Ruff hook to automatically fix linting issues and Gitleaks hook to detect secrets in the codebase. These changes improve code quality and security by enforcing standards and preventing sensitive data leaks before commits.